### PR TITLE
Add standalone html output using only the html examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bower_components
 .DS_Store
 dist
 index.html
+standalone.html

--- a/docs/support/fetchDocs.js
+++ b/docs/support/fetchDocs.js
@@ -8,6 +8,7 @@
 
 const fs = require('fs')
 const kmd = require('./kmd')
+const plainReporter = require('./plainReporter')
 
 const docFiles = [
   'Getting started',
@@ -37,4 +38,14 @@ module.exports = function fetchDocs () {
   })
 
   return { docs }
+}
+
+module.exports.altDocs = function () {
+    const docs = docFiles.map((name) => {
+        const parsedContent = plainReporter(fs.readFileSync(`docs/${name}.md`, { encoding: 'utf8' }))
+
+        return { name, parsedContent }
+    })
+
+    return { docs }
 }

--- a/docs/support/plainReporter.js
+++ b/docs/support/plainReporter.js
@@ -1,0 +1,29 @@
+/*
+ * Klarna flavoured markdown
+ *
+ * Basically, just a wrapper around marked.
+ * It adds some classes to allow proper styling and wraps code
+ * in example blocks.
+ *
+ */
+
+const md = require('marked')
+const renderer = new md.Renderer()
+
+renderer.heading = (text, level) => ''
+
+renderer.paragraph = (text) => ''
+
+renderer.list = (body, ordered) => ''
+
+renderer.code = (code, lang, escaped) => (
+    lang === 'html'
+      ? `<div class="example">${code}</div>`
+      : ''
+)
+
+renderer.codespan = (text, lang, escaped) => ' '
+
+renderer.link = (href, title, text) => ' '
+
+module.exports = (content) => md(content, { renderer })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,9 +39,15 @@ gulp.task('reload:sass', function () {
 });
 
 gulp.task('reload:docs', function () {
-    gulp.src('*.jade')
+    gulp.src('index.jade')
         .pipe(plumber(notify.onError("Error: <%= error.message %>")))
         .pipe(data(fetchDocs))
+        .pipe(jade())
+        .pipe(gulp.dest('./'))
+        .pipe(reload({stream: true}));
+    gulp.src('standalone.jade')
+        .pipe(plumber(notify.onError("Error: <%= error.message %>")))
+        .pipe(data(fetchDocs.altDocs))
         .pipe(jade())
         .pipe(gulp.dest('./'))
         .pipe(reload({stream: true}));
@@ -77,8 +83,12 @@ gulp.task('build:sass', function () {
 });
 
 gulp.task('build:jade', function () {
-    gulp.src('*.jade')
+    gulp.src('index.jade')
         .pipe(data(fetchDocs))
+        .pipe(jade())
+        .pipe(gulp.dest('./'));
+    gulp.src('standalone.jade')
+        .pipe(data(fetchDocs.altDocs))
         .pipe(jade())
         .pipe(gulp.dest('./'));
 });

--- a/standalone.jade
+++ b/standalone.jade
@@ -1,0 +1,26 @@
+doctype html
+<!--[if IE 8]>
+<html lang="en" class="ie8 cui__baseline">
+<![endif]-->
+<!--[if IE 9]>
+<html lang="en" class="ie9 cui__baseline">
+<![endif]-->
+<!--[if gt IE 9]><!-->
+<html class="cui__baseline" lang="en">
+<!--<![endif]-->
+head
+  meta(charset='utf-8')
+  meta(name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0')
+  link(rel='shortcut icon' href='favicon.ico')
+  title UI CSS Components
+
+  link(rel='stylesheet' href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600")
+
+  link(rel='stylesheet' href='dist/ui-toolkit.css')
+  link(rel='stylesheet' href='docs/support/doc.css')
+  link(rel='stylesheet' href='docs/support/standalone.css')
+
+body
+  each doc in docs
+    section(id="#{doc.name}")
+      != doc.parsedContent


### PR DESCRIPTION
Motivation: create a static page listing all component examples so that automatic visual regression testing can be done in a simple to parse page.

Ping @cpapazaf 
