### PR TITLE
Add error alert box

### DIFF
--- a/docs/Alert.md
+++ b/docs/Alert.md
@@ -1,0 +1,19 @@
+# Alert
+
+Alerts are blocks which contain information like errors.
+
+## Error
+
+```html
+<div class="cui__alert--error">
+  <h1 class="cui__alert__title">
+    An error alert box heading
+  </h1>
+  <p class="cui__alert__paragraph">
+    Some text inside helps to get an idea of how the alert would look like. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+  </p>
+  <p class="cui__alert__paragraph">
+    Correlation ID: <em>a4c531de-e35d-4901-93ae-44e32639b4b1</em>
+  </p>
+</div>
+```

--- a/docs/support/fetchDocs.js
+++ b/docs/support/fetchDocs.js
@@ -13,6 +13,7 @@ const plainReporter = require('./plainReporter')
 const docFiles = [
   'Getting started',
   'Baseline',
+  'Alert',
   'Block',
   'Button',
   'Checklist',

--- a/src/builds/ui-toolkit.scss
+++ b/src/builds/ui-toolkit.scss
@@ -1,6 +1,7 @@
 @import '../settings';
 $root: '';
 @import '../classes/baseline';
+@import '../classes/alert';
 @import '../classes/block';
 @import '../classes/button';
 @import '../classes/checklist';

--- a/src/classes/alert.scss
+++ b/src/classes/alert.scss
@@ -1,0 +1,15 @@
+@import '../mixins/index';
+
+.cui__alert {
+    &--error {
+        @include alert(map-get($colors, error-background), map-get($colors, error-hover), map-get($colors, error-text));
+    }
+}
+
+.cui__alert__paragraph {
+    @include alert__paragraph;
+}
+
+.cui__alert__title {
+    @include alert__title;
+}

--- a/src/components/alert.scss
+++ b/src/components/alert.scss
@@ -1,0 +1,2 @@
+@import '../settings';
+@import '../classes/alert';

--- a/src/mixins/alert.scss
+++ b/src/mixins/alert.scss
@@ -1,0 +1,27 @@
+@mixin alert ($background, $border, $color) {
+    @include typography(($grid * 2.6), regular);
+
+    background-color: $background;
+    border: 1px solid $border;
+    border-radius: $border-radius;
+    color: $color;
+    display: inline-block;
+    padding: ($grid * 4);
+    text-align: center;
+}
+
+@mixin alert__title {
+    @include typography(($grid * 2.8), semi-bold);
+
+    line-height: ($grid * 3);
+    margin: 0;
+    padding: ($grid * .4) 0 ($grid * .6);
+}
+
+@mixin alert__paragraph {
+    @include paragraph--primary-condensed;
+
+    color: inherit;
+    margin: 0;
+    padding: ($grid * .6) 0 ($grid * .4);
+}

--- a/src/mixins/index.scss
+++ b/src/mixins/index.scss
@@ -8,6 +8,7 @@
 @import 'helpers/typography';
 @import 'helpers/vertical-grid';
 
+@import 'alert';
 @import 'block';
 @import 'button';
 @import 'checkbox';

--- a/src/settings.scss
+++ b/src/settings.scss
@@ -47,7 +47,6 @@ $colors: (
     ultramarine: #2cc4b0,
     yellow: #ffc000,
     grey-label: #617788,
-
     grey-active-background: #f6f6f6,
     blue-hover: #66aae0,
     blue-focus: rgba(26, 140, 220, .8),
@@ -57,6 +56,8 @@ $colors: (
     error-hover: #ef8b6f,
     error-border: #e6bebe,
     error-shadow: rgba(230, 55, 6, .4),
+    error-text: #e63200,
+    error-background: #fff8f7,
     warning: #ecb800,
     warning-hover: #e2af4a,
     warning-border: #e6c88c


### PR DESCRIPTION
Fixes #43 

I took inspiration from how the Preview component was built.

Printscreen of the example:
![004](https://cloud.githubusercontent.com/assets/895361/16080882/2e98ba30-330b-11e6-97ff-0ced3f9f2a65.png)

I did a manual inspection of it in Chrome, Firefox and IE11 on Win7 with various document modes.
