### PR TITLE
Fixes yellow background on webkit's autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 7.3.2
+
+- Fix yellow background on fields with autocomplete on webkit
+
 # 7.3.1
 
 - Fix bounding box of tiny illustration

--- a/docs/Field.md
+++ b/docs/Field.md
@@ -66,6 +66,7 @@ ___
 - [Loading](#Field/loading)
 	- [big](#Field/loading/big)
 	- [big centered](#Field/loading/big centered)
+- [Autocomplete background](#Field/autocomplete-background)
 
 
 <a name="Field/examples"></a>
@@ -876,5 +877,17 @@ demo.
       ZIP Code
     </label>
     <input class="cui__field__input" value="94027" />
+</div>
+```
+
+<a name="Field/autocomplete-background"></a>
+## Autocomplete background
+
+```html
+<div class="cui__field">
+    <label class="cui__field__label">
+      Type your email
+    </label>
+    <input name="email" class="cui__field__input" type="email" />
 </div>
 ```

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -66,6 +66,7 @@ ___
 - [Loading](#Input/loading)
 	- [big](#Input/loading/big)
 	- [big centered](#Input/loading/big centered)
+- [Autocomplete background](#Input/autocomplete-background)
 
 
 <a name="Input/examples"></a>
@@ -900,5 +901,17 @@ or using Chrome inspector's mobile mode.
         ZIP Code
     </label>
     <input class="cui__input__input" value="94027" />
+</div>
+```
+
+<a name="Input/autocomplete-background"></a>
+## Autocomplete background
+
+```html
+<div class="cui__input">
+    <label class="cui__input__label">
+      Type your email
+    </label>
+    <input name="email" class="cui__input__input" type="email" />
 </div>
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/ui-css-components",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Klarna UI CSS Components",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {

--- a/src/settings.scss
+++ b/src/settings.scss
@@ -86,5 +86,5 @@ input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 input:-webkit-autofill:active {
-  transition: background-color 5000s ease-in-out 0s;
+    transition: background-color 5000s ease-in-out 0s;
 }

--- a/src/settings.scss
+++ b/src/settings.scss
@@ -78,3 +78,13 @@ $font-weights: (
 $border-radius: $grid;
 $border-radius-checkbox: ($grid * .4);
 $border-color: map-get($colors, grey-lines);
+
+// ================================================================
+//  General webkit autocomplete override (aka yellow background)
+// ================================================================
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  transition: background-color 5000s ease-in-out 0s;
+}


### PR DESCRIPTION
The strategy is to add a stupidly long transition to the field's background so it becomes yellow only after a long time. All other strategies have more downsides AFAIK. This is what we have been doing at myKlarna and it's live for quite some time. You can check it out at https://payusa.klarna.com/

Before:
<img width="741" alt="screen shot 2016-06-21 at 9 22 09 am" src="https://cloud.githubusercontent.com/assets/308196/16221312/5e99c32e-3792-11e6-85bf-73f33c26096d.png">

After:
<img width="718" alt="screen shot 2016-06-21 at 9 25 55 am" src="https://cloud.githubusercontent.com/assets/308196/16221311/5e974a72-3792-11e6-8221-ab5d1df6d252.png">
<img width="723" alt="screen shot 2016-06-21 at 9 23 33 am" src="https://cloud.githubusercontent.com/assets/308196/16221313/5e9c1bc4-3792-11e6-8fdd-ee6517b400dc.png">
