### PR TITLE
Add the 'focusable' attribute to svgs in the examples.

### DIFF
--- a/docs/Field.md
+++ b/docs/Field.md
@@ -618,7 +618,7 @@ demo.
 
 ```html
 <div class="cui__field--icon">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -637,7 +637,7 @@ demo.
 
 ```html
 <div class="cui__field--icon">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g transform="translate(2, 2)" class="cui__field--icon__icon__stroke">
       <circle cx="8" cy="8" r="7.5"></circle>
       <path d="M6.5,11 L4.5,9" stroke-linecap="round"></path>
@@ -657,7 +657,7 @@ demo.
 
 ```html
 <div class="cui__field--icon big">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -676,7 +676,7 @@ demo.
 
 ```html
 <div class="cui__field--icon is-focused">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -695,7 +695,7 @@ demo.
 
 ```html
 <div class="cui__field--icon is-filled is-focused">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -714,7 +714,7 @@ demo.
 
 ```html
 <div class="cui__field--icon is-error">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -733,7 +733,7 @@ demo.
 
 ```html
 <div class="cui__field--icon is-warning">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -752,7 +752,7 @@ demo.
 
 ```html
 <div class="cui__field--icon is-disabled">
-	<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
         <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
         <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -807,7 +807,7 @@ demo.
 
 ```html
 <div class="cui__field--icon is-centered is-filled is-focused">
-		<svg class="cui__field--icon__icon" viewBox="0 0 20 20">
+		<svg class="cui__field--icon__icon" viewBox="0 0 20 20" focusable="false">
 	    <g class="cui__field--icon__icon__fill" transform="translate(2.000000, 4.000000)">
 	        <path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 	        <path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>

--- a/docs/Input.md
+++ b/docs/Input.md
@@ -641,7 +641,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -660,7 +660,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
     <g transform="translate(2, 2)" class="cui__input--icon__icon__stroke">
       <circle cx="8" cy="8" r="7.5"></circle>
       <path d="M6.5,11 L4.5,9" stroke-linecap="round"></path>
@@ -680,7 +680,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon big">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -699,7 +699,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon is-focused">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -718,7 +718,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon is-filled is-focused">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -737,7 +737,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon is-error">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -756,7 +756,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon is-warning">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -775,7 +775,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon is-disabled">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>
@@ -830,7 +830,7 @@ or using Chrome inspector's mobile mode.
 
 ```html
 <div class="cui__input--icon is-centered is-filled is-focused">
-	<svg class="cui__input--icon__icon" viewBox="0 0 20 20">
+	<svg class="cui__input--icon__icon" viewBox="0 0 20 20" focusable="false">
 		<g class="cui__input--icon__icon__fill" transform="translate(2, 4)">
 			<path d="M13,11 L3,11 C1.897,11 1,10.103 1,9 L1,4 L15,4 L15,9 C15,10.103 14.103,11 13,11 M3,1 L13,1 C14.103,1 15,1.897 15,3 L1,3 C1,1.897 1.897,1 3,1 M13,0 L3,0 C1.35,0 0,1.35 0,3 L0,9 C0,10.65 1.35,12 3,12 L13,12 C14.65,12 16,10.65 16,9 L16,3 C16,1.35 14.65,0 13,0"></path>
 			<path d="M8.5,8 L3.5,8 C3.224,8 3,8.224 3,8.5 C3,8.776 3.224,9 3.5,9 L8.5,9 C8.776,9 9,8.776 9,8.5 C9,8.224 8.776,8 8.5,8"></path>


### PR DESCRIPTION
If you forget to set this attribute, IE will put focus
on the SVGs when you try to jump between fields with the
tab key.
