### PR TITLE
Better Landscape Dialogs on Mobile

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -26,6 +26,7 @@ rules:
         - breakpoint
         - mq
         - respond-to-wide
+        - respond-to-wide-and-tall
         - respond-to-ie
         - hidpi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.2.1
+
+- Better Dialog layout for landscape viewports
+
 # 9.2.0
 
 - Add Block Installments component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/ui-css-components",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Klarna UI CSS Components",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {

--- a/src/mixins/dialog.scss
+++ b/src/mixins/dialog.scss
@@ -13,7 +13,7 @@
         padding: ($grid * 6);
     }
 
-    @include respond-to-wide {
+    @include respond-to-wide-and-tall {
         border-radius: ($grid * 1.6);
         height: auto;
         margin: ($grid * 6) auto;
@@ -23,7 +23,7 @@
     }
 
     .wide & {
-        @include respond-to-wide {
+        @include respond-to-wide-and-tall {
             width: ($grid * 108);
         }
     }
@@ -45,7 +45,7 @@
         top: ($grid * 6);
     }
 
-    @include respond-to-wide {
+    @include respond-to-wide-and-tall {
         right: ($grid * 4);
         top: ($grid * 4);
     }
@@ -65,7 +65,7 @@
         }
     }
 
-    @include respond-to-wide {
+    @include respond-to-wide-and-tall {
         display: block;
 
         &--inner {
@@ -81,7 +81,7 @@
         display: table-cell;
     }
 
-    @include respond-to-wide {
+    @include respond-to-wide-and-tall {
         display: block;
 
         &--inner {
@@ -94,7 +94,7 @@
     height: 100%;
     width: 100%;
 
-    @include respond-to-wide {
+    @include respond-to-wide-and-tall {
         display: table-cell;
         text-align: center;
         vertical-align: middle;
@@ -105,7 +105,7 @@
     height: 100%;
     width: 100%;
 
-    @include respond-to-wide {
+    @include respond-to-wide-and-tall {
         display: table;
     }
 }

--- a/src/mixins/helpers/responsive.scss
+++ b/src/mixins/helpers/responsive.scss
@@ -1,7 +1,14 @@
 $mobile-max-width: 569px !default;
+$mobile-max-height: 500px !default;
 
 @mixin respond-to-wide($mobile-max-width: $mobile-max-width) {
     @media screen and (min-width: $mobile-max-width) {
+        @content;
+    }
+}
+
+@mixin respond-to-wide-and-tall($mobile-max-width: $mobile-max-width, $mobile-max-height: $mobile-max-height) {
+    @media screen and (min-width: $mobile-max-width) and (min-height: $mobile-max-height) {
         @content;
     }
 }


### PR DESCRIPTION
Use the full screen dialog in landscape viewports for mobile, in order to be able to display more content.

![screen shot 2016-08-19 at 17 05 57](https://cloud.githubusercontent.com/assets/313951/17814276/6359877a-662f-11e6-8b38-a0477228de13.png)
