### PR TITLE
Installments label should have regular font-weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.2.2
+
+- Use regular font-weight for installments component
+
 # 9.2.1
 
 - Better Dialog layout for landscape viewports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klarna/ui-css-components",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "description": "Klarna UI CSS Components",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {

--- a/src/classes/block.scss
+++ b/src/classes/block.scss
@@ -35,7 +35,7 @@
 
 .cui__block--installments__value__title {
     @include text-label;
-    @include typography(($grid * 2.2), semi-bold);
+    @include typography(($grid * 2.2), regular);
 }
 
 .cui__block--installments__value__content {


### PR DESCRIPTION
After reviewing the installments with Hannah, we noticed that the installment labels should have regular font-weight (400) instead of of semi-bold (600).

Before (left) and after (right):

<img width="1114" alt="screen shot 2016-08-24 at 16 31 04" src="https://cloud.githubusercontent.com/assets/569742/17934432/37d7845c-6a18-11e6-9f2d-b0b32aa54d61.png">
